### PR TITLE
Add checking proxy remote address

### DIFF
--- a/proxy_checker/proxy_checker.py
+++ b/proxy_checker/proxy_checker.py
@@ -86,7 +86,7 @@ class ProxyChecker:
 
         return ['-', '-']
 
-    def check_proxy(self, proxy, check_country=True):
+    def check_proxy(self, proxy, check_country=True, check_address=False):
         protocols = {}
         timeout = 0
 
@@ -116,17 +116,24 @@ class ProxyChecker:
         # Check timeout
         timeout = timeout // len(protocols)
 
-        if check_country:
-            return {
-                'country': country[0],
-                'country_code': country[1],
-                'protocols': list(protocols.keys()),
-                'anonymity': anonymity,
-                'timeout': timeout
-            }
+        # Check remote address
+        if check_address:
+            remote_regex = 'REMOTE_ADDR = (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
+            remote_addr = re.search(remote_regex, r['response'])
+            if remote_addr:
+                remote_addr = remote_addr.group(1)
 
-        return {
+        results = {
             'protocols': list(protocols.keys()),
             'anonymity': anonymity,
             'timeout': timeout
         }
+
+        if check_country:
+            results['country'] = country[0]
+            results['country_code'] = country[1]
+
+        if check_address:
+            results['remote_address'] = remote_addr
+
+        return results

--- a/proxy_checker/proxy_checker.py
+++ b/proxy_checker/proxy_checker.py
@@ -105,21 +105,22 @@ class ProxyChecker:
         if (len(protocols) == 0):
             return False
 
+        r = protocols[random.choice(list(protocols.keys()))]['response']
+
         # Get country
         if check_country:
             country = self.get_country(proxy.split(':')[0])
 
         # Check anonymity
-        anonymity = self.parse_anonymity(
-            protocols[random.choice(list(protocols.keys()))]['response'])
+        anonymity = self.parse_anonymity(r)
 
         # Check timeout
         timeout = timeout // len(protocols)
 
         # Check remote address
         if check_address:
-            remote_regex = 'REMOTE_ADDR = (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
-            remote_addr = re.search(remote_regex, r['response'])
+            remote_regex = r'REMOTE_ADDR = (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
+            remote_addr = re.search(remote_regex, r)
             if remote_addr:
                 remote_addr = remote_addr.group(1)
 


### PR DESCRIPTION
Some proxies don't use the IP address used for connecting to them as their external address that websites see. This change allows you to check the IP address that a website will see when connecting through the proxy by parsing the REMOTE_ADDR field from the proxy judge's response.