### PR TITLE
Updated list of proxy judges

### DIFF
--- a/proxy_checker/proxy_checker.py
+++ b/proxy_checker/proxy_checker.py
@@ -9,8 +9,11 @@ class ProxyChecker:
     def __init__(self):
         self.ip = self.get_ip()
         self.proxy_judges = [
-            'http://proxyjudge.us/azenv.php',
-            'http://mojeip.net.pl/asdfa/azenv.php'
+            'https://www.proxy-listen.de/azenv.php',
+            'http://www.sbjudge3.com/azenv.php',
+            'http://mojeip.net.pl/asdfa/azenv.php',
+            'http://httpheader.net/azenv.php',
+            'http://pascal.hoez.free.fr/azenv.php'
         ]
 
     def get_ip(self):


### PR DESCRIPTION
Previous list was outdated, e.g. proxyjudge.us is not available anymore, and therefore added some new URLs. I have tested the updated list without problems.